### PR TITLE
Add a UART to MDIO bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: clean
 clean:
+	rm -rf dist-newstyle
 	rm -rf verilog
 	rm -rf netlist
 

--- a/UART_MDIO.py
+++ b/UART_MDIO.py
@@ -1,0 +1,51 @@
+import serial
+from struct import pack, unpack
+from time import sleep
+import sys
+
+READ = 0b0
+WRITE = 0b1
+
+# Format: (OP, PHY, REG, D16)
+w_req = []
+for i in range(5**2):
+     w_req.append(
+          (READ, i, 0b1, 0xf)
+     )
+r_req = []
+for i in range(5**2):
+     r_req.append(
+          (READ, i, 0b1, 0xf)
+     )
+
+# Check format is correct
+
+def print_instruction(instruction):
+    (instr, addr1, addr2, data) = instruction
+    print(pack('>?', instr))
+    print(pack('>B', addr1))
+    print(pack('>B', addr2))
+    print(pack('>H', data))
+    print("_____________________________")
+
+try:
+    with serial.Serial('/dev/ttyUSB0', 9600, timeout=1) as ser:
+        for (instr, addr1, addr2, data) in w_req:
+            ser.write(pack(">B", instr))
+            ser.write(pack(">B", addr1))
+            ser.write(pack(">B", addr2))
+            ser.write(pack(">H", data))
+
+        for (instr, addr1, addr2, data) in r_req:
+            ser.write(pack(">B", instr))
+            ser.write(pack(">B", addr1))
+            ser.write(pack(">B", addr2))
+            ser.write(pack(">H", data))
+            (result, ) = unpack(">B", ser.read(1))
+            (result2, ) = unpack(">B", ser.read(1))
+            print("first byte: {}, second byte: {}".format(bin(result), bin(result2)))
+            print("result: {}".format((result << 8) ^ result2))
+
+except Exception as e:
+    print(e)
+    print("Could not open device at port (check that its plugged in)")

--- a/clash-eth.cabal
+++ b/clash-eth.cabal
@@ -83,6 +83,7 @@ library
   exposed-modules:
     Clash.Lattice.ECP5.Colorlight.TopEntity
     Clash.Cores.Ethernet.Ethernet
+    Clash.Cores.Ethernet.MDIO
     Clash.Lattice.ECP5.Prims
     Clash.Lattice.ECP5.Colorlight.CRG
   default-language: Haskell2010

--- a/src/Clash/Cores/Ethernet/MDIO.hs
+++ b/src/Clash/Cores/Ethernet/MDIO.hs
@@ -1,0 +1,140 @@
+{-# language NumericUnderscores #-}
+
+module Clash.Cores.Ethernet.MDIO (MDIOResponse (..), MDIORequest (..), mdioComponent) where
+
+import Clash.Prelude
+import Data.Maybe ( isJust )
+
+data MDIORequest
+  -- | PHY address, REG address
+  = MDIORead (Unsigned 5) (Unsigned 5)
+  -- | PHY address, REG address, 16-bit data
+  | MDIOWrite (Unsigned 5) (Unsigned 5) (BitVector 16)
+  deriving (Show, ShowX, Eq, Generic, NFDataX, BitPack)
+
+data MDIOResponse
+  = MDIOReadResult (BitVector 16)
+  -- ^ contents of register that was read
+  | MDIOWriteAck
+  deriving (Show, ShowX, Eq, Generic, NFDataX, BitPack)
+
+data State
+  = SendPreamble (Index 32) (BitVector 14) (Maybe (BitVector 16))
+  -- ^ Send 32 times a 1
+  | SendSTOPPARA (Index 14) (BitVector 14) (Maybe (BitVector 16))
+  -- ^ Send the STart, OPeration, Physical Address and Register Address
+  | SendTAWrite (Index 2) (BitVector 16)
+  -- ^ Send 10
+  | SendTARead
+  -- ^ Wait while receiving Z0 (gives control to other side)
+  | WriteD16 (Index 16) (BitVector 16)
+  -- ^ Write data to a register
+  | ReadD16 (Index 16) (BitVector 16)
+  -- ^ Receive data from a register
+  | Idle
+  -- ^ Waiting for the bridge to issue a new request
+  deriving (Show, Eq, Generic, NFDataX)
+
+-- | State transitions in the mealy machine
+nextStep :: State -> Maybe MDIORequest -> Bit -> (State, Maybe Bit, Maybe MDIOResponse)
+-- Nothing happens
+nextStep Idle Nothing _ = (Idle, Nothing, Nothing)
+-- Receive a request from the bridge
+nextStep Idle (Just req) _   = (SendPreamble 0 stoppara write_data, Nothing, Nothing)
+    where
+        (stoppara, write_data) = case req of
+            (MDIORead phy reg) -> (0b0110 ++# (pack phy) ++# (pack reg), Nothing)
+            (MDIOWrite phy reg dat) -> (0b0101 ++# (pack phy) ++# (pack reg), Just dat)
+
+-- Send Preamble
+nextStep (SendPreamble cnt stoppara d) _ _ = (nextState, Just 1, Nothing)
+  where
+    nextState
+      | cnt < 31 = SendPreamble (cnt+1) stoppara d
+      | otherwise = SendSTOPPARA 0 stoppara d
+
+-- Send all 14 bits that are the same for both read and write requests
+-- STart, OPeration, Physical Address, Register Address
+nextStep (SendSTOPPARA cnt sendBv dat) _ _ = (nextState, Just out, Nothing)
+  where
+    -- MSB first!
+    out = msb sendBv
+    bv' = shiftL sendBv 1
+    nextState
+      | cnt < 13 = SendSTOPPARA (cnt+1) bv' dat
+      | otherwise = case dat of
+                        Just d -> SendTAWrite 0 d
+                        Nothing -> SendTARead
+
+-- Wait out the turn-around field for Read
+-- Calibrated by reading the OUI from the PHY identifier 1 register (address 0x02)
+nextStep SendTARead _ _ = (ReadD16 0 0, Nothing, Nothing)
+
+-- Receive data for Read
+nextStep (ReadD16 cnt bv) _ inp = (nextState, Nothing, response)
+  where
+    -- Receive a bit from the register we're reading
+    -- Bit 15 first, bit 0 last!
+    bv' = replaceBit (0 :: Index 16) inp $ shiftL bv 1
+    (response, nextState)
+      | cnt >= 15 = (Just $ MDIOReadResult bv', Idle)
+      | otherwise = (Nothing, ReadD16 (cnt+1) bv')
+
+-- Send turn-around field for Write
+nextStep (SendTAWrite cnt d) _ _ = (nextState, Just out, Nothing)
+    where
+        (out, nextState)
+            | cnt == 0  = (1, SendTAWrite 1 d)
+            | otherwise = (0, WriteD16 0 d)
+
+-- Write data to register
+nextStep (WriteD16 cnt dat) _ _ = (nextState, Just out, response)
+  where
+    -- Get a bit from the register write
+    -- Bit 15 first, bit 0 last!
+    out = msb dat
+    bv' = shiftL dat 1
+    response
+      | cnt == 15 = Just $ MDIOWriteAck
+      | otherwise = Nothing
+    nextState
+      | cnt < 15 = WriteD16 (cnt+1) bv'
+      | otherwise = Idle
+
+
+-- | Calculate how many cycles in `dom` fit into a `MDC` cycle
+-- | We're aiming for 1.5Mhz so a single clock cycle is 10^12 / (1.5 * 10^6) = 666_666 picoseconds
+-- | It is then divided by 2 because `MDCCycle` only describes half of a clock cycle
+-- |
+-- | This is slightly slower than the 2.5Mhz maximum but still more than fast enough.
+type MDCCycle (dom :: Domain) = DivRU 333_333 (DomainPeriod dom)
+
+{-# NOINLINE mdioComponent #-}
+mdioComponent
+  :: forall dom period
+  . (HiddenClockResetEnable dom, KnownDomain dom, DomainPeriod dom ~ period, KnownNat period, (1 <=? period) ~ 'True)
+  -- | eth_mdio in
+  => Signal dom Bit
+  -- | Receive a request from the bridge
+  -> Signal dom (Maybe MDIORequest)
+  -- |
+  -- 1. eth_mdio out
+  -- 2. Output result or ACK when we have it
+  -- 3. MDC signal, the clock for MDIO
+  -> ( Signal dom (Maybe Bit)
+     , Signal dom (Maybe MDIOResponse)
+     , Signal dom Bit
+     )
+mdioComponent mdioIn req = (mdioOut, response', boolToBit <$> mdc)
+  where
+     -- Artificially run at 1.5Mhz
+    mdc = oscillate False (SNat @(MDCCycle dom))
+    mdcEn = isFalling False mdc
+
+    (st0, mdioOut, response) = unbundle $ nextStep <$> st1 <*> req <*> mdioIn
+    st1 = regEn Idle mdcEn st0
+
+    -- Only output the result or ACK once
+    justOnce False v = v
+    justOnce _ _ = Nothing
+    response' = justOnce <$> (register False $ isJust <$> response) <*> response

--- a/src/Clash/Lattice/ECP5/Colorlight/Bridge.hs
+++ b/src/Clash/Lattice/ECP5/Colorlight/Bridge.hs
@@ -1,0 +1,131 @@
+{-# language FlexibleContexts #-}
+
+module Clash.Lattice.ECP5.Colorlight.Bridge (uartToMdioBridge) where
+
+import Clash.Cores.Ethernet.MDIO
+import Clash.Cores.UART
+import Clash.Prelude
+
+
+data Instruction = UARTRead | UARTWrite | UARTNoOp
+  deriving (Show, Eq, Generic, NFDataX)
+
+-- functions for instruction decoding
+decodeUARTInstr :: BitVector 8 -> Instruction
+decodeUARTInstr 0 = UARTRead
+decodeUARTInstr 1 = UARTWrite
+decodeUARTInstr _ = UARTNoOp
+
+data BridgeState
+  --  read/write common states
+  = Idle
+  | UARTReceive (Index 5) (Vec 5 (BitVector 8))
+  | MDIOAwaitResponse MDIORequest
+  | UARTSend (Index 2) (Vec 2 (BitVector 8))
+  deriving (Show, Eq, Generic, NFDataX)
+
+type UARTInput = (Maybe (BitVector 8), Bool)
+type UARTOutput = (BitVector 8)
+
+bridgeStep
+  :: BridgeState
+  -> (UARTInput, Maybe MDIOResponse)
+  -> (BridgeState, (Maybe UARTOutput, Maybe MDIORequest))
+
+{- Idle -}
+bridgeStep Idle ((Nothing, _), _)
+  = (Idle, noOutput)
+    where
+      -- state does not produce output
+      noOutput = (Nothing, Nothing)
+
+bridgeStep Idle ((Just bv, _), _)
+  = (nextState, noOutput)
+    where
+      -- state does not produce output
+      noOutput = (Nothing, Nothing)
+      -- initialize regs and state
+      regs = bv +>> repeat 0
+      nextState = UARTReceive 3 regs
+
+{- Receiving data from UART -}
+bridgeStep (UARTReceive idx regs) ((Nothing, _), _)
+  = (nextState, noOutput)
+  where
+    -- state does not produce output
+    noOutput = (Nothing, Nothing)
+    nextState = UARTReceive idx regs
+
+bridgeStep (UARTReceive idx regs) ((Just bv, _), _)
+  | idx == 0 = (nextState, noOutput)
+  | otherwise = (,noOutput) $ UARTReceive (idx - 1) regs'
+  where
+    -- state does not produce output
+    noOutput = (Nothing, Nothing)
+    -- update regs
+    regs' = (bv +>> regs)
+    -- decode the uart insturction
+    instruction = decodeUARTInstr $ regs' !! (4 :: Index 5)
+    -- request builder
+    phyaddr = unpack . resize $ regs' !! (3 :: Index 5)
+    regaddr = unpack . resize $ regs' !! (2 :: Index 5)
+    d16data = unpack (regs' !! (1 :: Index 5)) ++# (regs' !! (0 :: Index 5))
+    readReq = MDIORead phyaddr regaddr
+    writeReq = MDIOWrite phyaddr regaddr d16data
+    -- go to next state
+    nextState = case instruction of
+                  UARTRead -> MDIOAwaitResponse readReq
+                  UARTWrite -> MDIOAwaitResponse writeReq
+                  _ -> Idle
+
+{- Keep sending data to MDIO until response -}
+bridgeStep s@(MDIOAwaitResponse req) (_, Nothing)
+  = (s, (Nothing, pure req))
+
+bridgeStep (MDIOAwaitResponse _) (_, Just MDIOWriteAck)
+  = (Idle, (Nothing, Nothing))
+
+bridgeStep (MDIOAwaitResponse _) (_, Just (MDIOReadResult bv))
+  = (nextState, (Nothing, Nothing))
+    where
+      -- next we send data to uart
+      nextState = UARTSend 1 regs
+      -- initialize regs
+      regs = bv1 :> bv2 :> Nil
+      (bv1, bv2) = split bv
+
+{- Keep sending data to MDIO until acked -}
+bridgeStep s@(UARTSend idx regs) ((_, False), _)
+  = (s, (uartOutput, Nothing))
+  where
+    uartOutput = pure $ regs !! idx
+
+bridgeStep (UARTSend idx regs) ((_, True), _)
+  | idx > 0 = (nextState, (uartOutput, Nothing))
+  | otherwise = (Idle, noOutput)
+  where
+    nextState = UARTSend (idx-1) regs
+    uartOutput = pure $ regs !! (idx-1)
+    noOutput = (Nothing, Nothing)
+
+{-# NOINLINE uartToMdioBridge #-}
+uartToMdioBridge :: forall (dom :: Domain) (baud :: Nat) . ValidBaud dom baud
+  => KnownDomain dom
+  => HiddenClockResetEnable dom
+  => SNat baud
+  -> Signal dom Bit -- uart rx pin
+  -> Signal dom (Maybe MDIOResponse) -- get result of request from mdio component
+  -> (Signal dom Bit -- uart tx pin
+  , Signal dom (Maybe MDIORequest)) -- output request to mdio component
+uartToMdioBridge baud uartRxBit mdioResponse = (uartTxBit, mdioRequest)
+  where
+    uart' = uart baud
+    (rxWord, uartTxBit, ack) = uart' uartRxBit txByte
+
+    -- define state signal
+    initState = Idle
+
+    -- define output signals
+    txByte :: Signal dom (Maybe (BitVector 8))
+    mdioRequest :: Signal dom (Maybe MDIORequest)
+    (txByte, mdioRequest) = unbundle $ mealy bridgeStep initState $ bundle (bundle (rxWord, ack), mdioResponse)


### PR DESCRIPTION
Implements #2.

I've marked it as a draft PR because we still need the python script and `uartToMdioBridge` before the entire system can be reviewed.