### PR TITLE
Split inputs and outputs of topEntity into data types

### DIFF
--- a/pinout.lpf
+++ b/pinout.lpf
@@ -12,9 +12,9 @@ LOCATE COMP "uart_rx" SITE "R7";
 IOBUF PORT "uart_rx" IO_TYPE=LVCMOS33;
 
 # sdram
-LOCATE COMP "sdram_clock" SITE "C8";
-IOBUF PORT "sdram_clock" IO_TYPE=LVCMOS33;
-IOBUF PORT "sdram_clock" SLEWRATE=FAST;
+LOCATE COMP "sdram_clk" SITE "C8";
+IOBUF PORT "sdram_clk" IO_TYPE=LVCMOS33;
+IOBUF PORT "sdram_clk" SLEWRATE=FAST;
 LOCATE COMP "sdram_a[0]" SITE "A9";
 IOBUF PORT "sdram_a[0]" IO_TYPE=LVCMOS33;
 IOBUF PORT "sdram_a[0]" SLEWRATE=FAST;

--- a/src/Clash/Lattice/ECP5/Colorlight/TopEntity.hs
+++ b/src/Clash/Lattice/ECP5/Colorlight/TopEntity.hs
@@ -9,39 +9,35 @@ import Clash.Cores.UART
 
 data RGMIIChannel domain = RGMIIChannel
   {
-    rgmii_rx_clk :: Clock domain,
-    rgmii_rx_ctl :: Signal domain Bit,
-    rgmii_rx_data :: Signal domain (BitVector 4),
-    rgmii_tx_clk :: Clock domain,
-    rgmii_tx_ctl :: Signal domain Bit,
-    rgmii_tx_data :: Signal domain (BitVector 4)
+    rgmii_clk  :: "clk" ::: Clock domain,
+    rgmii_ctl  :: "ctl" ::: Signal domain Bit,
+    rgmii_data :: "data" ::: Signal domain (BitVector 4)
   }
 
 data SDRAMOut domain = SDRAMOut
   {
-    sdram_clock :: "sdram_clock" :::Clock domain,
-    sdram_a :: "sdram_a" ::: Signal domain (BitVector 11),
-    sdram_we_n :: "sdram_we_n" ::: Signal domain Bit,
-    sdram_ras_n :: "sdram_ras_n" :::Signal domain Bit,
-    sdram_cas_n :: "sdram_cas_n" ::: Signal domain Bit,
-    sdram_ba :: "sdram_ba" ::: Signal domain (BitVector 2),
-    sdram_dq :: "sdram_dq" ::: BiSignalOut 'Floating domain 32
+    sdram_clock :: "clk" :::Clock domain,
+    sdram_a :: "a" ::: Signal domain (BitVector 11),
+    sdram_we_n :: "we_n" ::: Signal domain Bit,
+    sdram_ras_n :: "ras_n" :::Signal domain Bit,
+    sdram_cas_n :: "cas_n" ::: Signal domain Bit,
+    sdram_ba :: "ba" ::: Signal domain (BitVector 2),
+    sdram_dq :: "dq" ::: BiSignalOut 'Floating domain 32
   }
 
 data MDIOOut domain = MDIOOut
   {
-    mdio_out :: "eth_mdio" ::: BiSignalOut 'Floating domain 1,
-    mdio_in :: "eth_mdio" ::: BiSignalIn 'Floating domain 1,
-    mdio_mdc :: "eth_mdc" ::: Signal domain Bit
+    mdio_out :: "mdio" ::: BiSignalOut 'Floating domain 1,
+    mdio_mdc :: "mdc" ::: Signal domain Bit
   }
 
 data HubOut domain = HubOut
   {
-    hub_clk :: "hub_clk" ::: Signal domain Bit,
-    hub_line_select :: "hub_line_select" ::: Signal domain (BitVector 5),
-    hub_latch :: "hub_latch" ::: Signal domain Bit,
-    hub_output_enable :: "hub_output_enable" ::: Signal domain Bit,
-    hub_data :: "hub_data" ::: Signal domain (BitVector 48)
+    hub_clk :: "clk" ::: Signal domain Bit,
+    hub_line_select :: "line_select" ::: Signal domain (BitVector 5),
+    hub_latch :: "latch" ::: Signal domain Bit,
+    hub_output_enable :: "output_enable" ::: Signal domain Bit,
+    hub_data :: "data" ::: Signal domain (BitVector 48)
   }
 
 topEntity
@@ -59,18 +55,8 @@ topEntity
      , "hub" ::: HubOut Dom50
      )
 
-topEntity clk25 uartRxBit dq_in _mdio_in eth0_rx eth1_rx =
+topEntity clk25 uartRxBit dq_in mdio_in eth0_rx eth1_rx =
   let
-    RGMIIChannel { rgmii_rx_clk = eth0RxClk
-                 , rgmii_rx_ctl = _eth0RxCtl
-                 , rgmii_rx_data = _eth0RxData
-                 } = eth0_rx
-
-    RGMIIChannel { rgmii_rx_clk = eth1RxClk
-                , rgmii_rx_ctl = _eth1RxCtl
-                , rgmii_rx_data = _eth1RxData
-                } = eth1_rx
-
     (clk50, rst50) = crg clk25
     en50 = enableGen
 
@@ -85,7 +71,7 @@ topEntity clk25 uartRxBit dq_in _mdio_in eth0_rx eth1_rx =
     dq :: Signal Dom50 (BitVector 32)
     mdio :: Signal Dom50 Bit
     (dq_out, dq) = bb dq_in onoff (ofs1p3bx clk50 rst50 en50 dqReg) -- sdram_dq
-    (eth_mdio_out, mdio) = bb _mdio_in onoff (ofs1p3bx clk50 rst50 en50 mdioReg) -- sdram_dq
+    (eth_mdio_out, mdio) = bb mdio_in onoff (ofs1p3bx clk50 rst50 en50 mdioReg) -- sdram_dq
 
     dqReg = ifs1p3bx clk50 rst50 en50 dq
     mdioReg = ifs1p3bx clk50 rst50 en50 mdio
@@ -105,24 +91,17 @@ topEntity clk25 uartRxBit dq_in _mdio_in eth0_rx eth1_rx =
           }
       , MDIOOut
           { mdio_out = eth_mdio_out
-          , mdio_in = _mdio_in
           , mdio_mdc = pure 0
           }
       , RGMIIChannel  -- eth0
-          { rgmii_tx_clk = eth0RxClk
-          , rgmii_tx_ctl = pure 0
-          , rgmii_tx_data = pure 0
-          , rgmii_rx_clk = eth0RxClk
-          , rgmii_rx_ctl = _eth0RxCtl
-          , rgmii_rx_data = _eth0RxData
+          { rgmii_clk = rgmii_clk eth0_rx
+          , rgmii_ctl = rgmii_ctl eth0_rx
+          , rgmii_data = rgmii_data eth0_rx
           }
       , RGMIIChannel  --eth1
-          { rgmii_tx_clk = eth1RxClk
-          , rgmii_tx_ctl = pure 0
-          , rgmii_tx_data = pure 0
-          , rgmii_rx_clk = eth1RxClk
-          , rgmii_rx_ctl = _eth1RxCtl
-          , rgmii_rx_data = _eth1RxData
+          { rgmii_clk = rgmii_clk eth1_rx
+          , rgmii_ctl = rgmii_ctl eth1_rx
+          , rgmii_data = rgmii_data eth1_rx
           }
       , HubOut
           { hub_clk = pure 0


### PR DESCRIPTION
Split the input and output of the original topEntity with the following data types:

```haskell
data TopEntityInputs = TopEntityInputs
  { clk25       :: "clk25" ::: Clock Dom25
  , uart_rx   :: "uart_rx" ::: Signal Dom50 Bit
  , sdramDqIn   :: "sdram_dq" ::: BiSignalIn 'Floating Dom50 32
  , ethMdioIn   :: "eth_mdio" ::: BiSignalIn 'Floating Dom50 1
  , eth0RxClk   :: "eth0_rx_clk" ::: Clock DomEth0
  , eth0RxCtl   :: "eth0_rx_ctl" ::: Signal DomEth0 Bit
  , eth0RxData  :: "eth0_rx_data" ::: Signal DomEth0 (BitVector 4)
  , eth1RxClk   :: "eth1_rx_clk" ::: Clock DomEth1
  , eth1RxCtl   :: "eth1_rx_ctl" ::: Signal DomEth1 Bit
  , eth1RxData  :: "eth1_rx_data" ::: Signal DomEth1 (BitVector 4)
  }

data TopEntityOutputs = TopEntityOutputs
  { uart_tx           :: "uart_tx" ::: Signal Dom50 Bit
  , sdram_clock       :: "sdram_clock" ::: Clock Dom50
  , sdram_a           :: "sdram_a" ::: Signal Dom50 (BitVector 11)
  , sdram_we_n        :: "sdram_we_n" ::: Signal Dom50 Bit
  , sdram_ras_n       :: "sdram_ras_n" ::: Signal Dom50 Bit
  , sdram_cas_n       :: "sdram_cas_n" ::: Signal Dom50 Bit
  , sdram_ba          :: "sdram_ba" ::: Signal Dom50 (BitVector 2)
  , sdram_dq          :: "sdram_dq" ::: BiSignalOut 'Floating Dom50 32
  , eth_mdio          :: "eth_mdio" ::: BiSignalOut 'Floating Dom50 1
  , eth_mdc           :: "eth_mdc" ::: Signal Dom50 Bit
  , eth_rst_n         :: "eth_rst_n" ::: Signal Dom50 Bit
  , eth0_tx_clk       :: "eth0_tx_clk" ::: Clock DomEth0
  , eth0_tx_ctl       :: "eth0_tx_ctl" ::: Signal DomEth0 Bit
  , eth0_tx_data      :: "eth0_tx_data" ::: Signal DomEth0 (BitVector 4)
  , eth1_tx_clk       :: "eth1_tx_clk" ::: Clock DomEth1
  , eth1_tx_ctl       :: "eth1_tx_ctl" ::: Signal DomEth1 Bit
  , eth1_tx_data      :: "eth1_tx_data" ::: Signal DomEth1 (BitVector 4)
  , hub_clk           :: "hub_clk" ::: Signal Dom50 Bit
  , hub_line_select   :: "hub_line_select" ::: Signal Dom50 (BitVector 5)
  , hub_latch         :: "hub_latch" ::: Signal Dom50 Bit
  , hub_output_enable :: "hub_output_enable" ::: Signal Dom50 Bit
  , hub_data          :: "hub_data" ::: Signal Dom50 (BitVector 48)
  }
```

The echo and uartCPU program still work with this implementation.