### PR TITLE
Add `delayg`, add initial value to `delayf`

### DIFF
--- a/src/Clash/Lattice/ECP5/Prims.hs
+++ b/src/Clash/Lattice/ECP5/Prims.hs
@@ -235,45 +235,48 @@ oddrx1f clk rst xs ys = ddrOut clk rst enableGen (unpack 0) ((,) <$> xs <*> ys)
 
 -- | Dynamic delay element
 delayf
-  :: Signal domLogic Bit -- 0
-  -- ^ LOADN: 0 on this line resets to 0 delay setting
-  -> Signal domLogic Bit -- 1
-  -- ^ MOVE: Pulsing changes delay on falling edge according to DIRECTION
+  :: delValue <= 127     -- 0
+  => SNat delValue       -- 1
+  -- ^ Delay in 25ps increments, can be at most 127
   -> Signal domLogic Bit -- 2
+  -- ^ LOADN: 0 on this line resets to 0 delay setting
+  -> Signal domLogic Bit -- 3
+  -- ^ MOVE: Pulsing changes delay on falling edge according to DIRECTION
+  -> Signal domLogic Bit -- 4
   -- ^ DIRECTION: 0 to increase delay by 25ps, 1 to decrease delay by 25ps
   -- Delay min is 0(0ps) max is 127(3175ps) and it's saturating.
-  -> Signal domDelay a   -- 3
+  -> Signal domDelay a   -- 5
   -- ^ Data input from pin or output register block
   -> Signal domDelay a
-delayf !_ !_ !_ inp = inp
+delayf !_ !_ !_ !_ inp = inp
 {-# ANN delayf (InlinePrimitive [Verilog] $ unindent [i|
   [ { "BlackBox" :
       { "name"     : "Clash.Lattice.ECP5.Prims.delayf"
       , "kind"     : "Declaration"
       , "template" :
   "// DELAYF begin
-  ~IF~ISSCALAR[3]~THEN
+  ~IF~ISSCALAR[5]~THEN
     DELAYF #(
       .DEL_MODE(\\"USER_DEFINED\\"),
-      .DEL_VALUE(7'd0)
+      .DEL_VALUE(7'd~LIT[1])
     ) ~GENSYM[DELAYF_INST][3] (
-      .A(~VAR[d][3]),
-      .LOADN(~VAR[loadn][0]),
-      .MOVE(~VAR[move][1]),
-      .DIRECTION(~VAR[direction][2]),
+      .A(~VAR[d][5]),
+      .LOADN(~VAR[loadn][2]),
+      .MOVE(~VAR[move][3]),
+      .DIRECTION(~VAR[direction][4]),
       .Z(~RESULT)
     );
   ~ELSE
     genvar ~GENSYM[i][0];
-    for (~SYM[0] = 0; ~SYM[0] < ~SIZE[~TYP[3]]; ~SYM[0] = ~SYM[0] + 1) begin : ~GENSYM[DELAYF_GEN][1]
+    for (~SYM[0] = 0; ~SYM[0] < ~SIZE[~TYP[5]]; ~SYM[0] = ~SYM[0] + 1) begin : ~GENSYM[DELAYF_GEN][1]
       DELAYF #(
         .DEL_MODE(\\"USER_DEFINED\\"),
-        .DEL_VALUE(7'd0)
+        .DEL_VALUE(7'd~LIT[1])
       ) ~GENSYM[DELAYF_INST][2] (
-        .A(~VAR[d][3][~SYM[0]]),
-        .LOADN(~VAR[loadn][0]),
-        .MOVE(~VAR[move][1]),
-        .DIRECTION(~VAR[direction][2]),
+        .A(~VAR[d][5][~SYM[0]]),
+        .LOADN(~VAR[loadn][2]),
+        .MOVE(~VAR[move][3]),
+        .DIRECTION(~VAR[direction][4]),
         .Z(~RESULT[~SYM[0]])
       );
     end
@@ -284,3 +287,48 @@ delayf !_ !_ !_ inp = inp
   ]
   |]) #-}
 {-# NOINLINE delayf #-}
+
+-- | Static delay element
+--
+-- Similar to `delayf`, equivalent to:
+-- > \delay a -> delayf delay 0 0 0 a
+delayg
+  :: delValue <= 127     -- 0
+  => SNat delValue       -- 1
+  -- ^ Delay in 25ps increments, can be at most 127
+  -> Signal domDelay a   -- 2
+  -- ^ Data input from pin or output register block
+  -> Signal domDelay a
+delayg !_ inp = inp
+{-# ANN delayg (InlinePrimitive [Verilog] $ unindent [i|
+  [ { "BlackBox" :
+      { "name"     : "Clash.Lattice.ECP5.Prims.delayg"
+      , "kind"     : "Declaration"
+      , "template" :
+  "// DELAYG begin
+  ~IF~ISSCALAR[2]~THEN
+    DELAYG #(
+      .DEL_MODE(\\"USER_DEFINED\\"),
+      .DEL_VALUE(7'd~LIT[1])
+    ) ~GENSYM[DELAYG_INST][3] (
+      .A(~VAR[d][2]),
+      .Z(~RESULT)
+    );
+  ~ELSE
+    genvar ~GENSYM[i][0];
+    for (~SYM[0] = 0; ~SYM[0] < ~SIZE[~TYP[2]]; ~SYM[0] = ~SYM[0] + 1) begin : ~GENSYM[DELAYG_GEN][1]
+      DELAYG #(
+        .DEL_MODE(\\"USER_DEFINED\\"),
+        .DEL_VALUE(7'd~LIT[1])
+      ) ~GENSYM[DELAYG_INST][2] (
+        .A(~VAR[d][2][~SYM[0]]),
+        .Z(~RESULT[~SYM[0]])
+      );
+    end
+  ~FI
+  // DELAYG end"
+      }
+    }
+  ]
+  |]) #-}
+{-# NOINLINE delayg #-}


### PR DESCRIPTION
Mostly copy-pasted from Discord code by Rowan.

Changes were a slight bit of documentation and adding `Clash.Lattice.` to the BlackBox name.

Tested as synthesizing with `make bitstream` succeeding, for the test I used both `delayg` and `delayf` in `TopEntity.hs`.