### PR TITLE
Made separate pll125 primitive

### DIFF
--- a/src/Clash/Lattice/ECP5/Colorlight/CRG.hs
+++ b/src/Clash/Lattice/ECP5/Colorlight/CRG.hs
@@ -85,7 +85,7 @@ crg clkin = (clk50, clkEthTx, rst50, rstEthTx)
     (clk50, locked50) = pll50 clkin
     (clkEthTx, lockedEthTx) = pll125 clkin
     rst50 = resetSynchronizer clk50 (unsafeFromLowPolarity locked50)
-    rstEthTx = resetSynchronizer clkEthTx (unsafeFromLowPolarity $ unsafeSynchronizer clk50 clkEthTx locked50)
+    rstEthTx = resetSynchronizer clkEthTx (unsafeFromLowPolarity lockedEthTx)
 
 -- | Generate a 50Mhz clock from 25Mhz
 pll50


### PR DESCRIPTION
It was mentioned that the ECP5 on the colorlight board has two PLL resources. I wired up the new primitive as suggested (like the pll50), but I don't know if the fact that they are used in two different resources means I had to change anything in particular.